### PR TITLE
add mqtt worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 release: rake db:migrate
+worker: bundle exec rake mqtt


### PR DESCRIPTION
#### Board:
* [Ticket #34](https://github.com/rootstrap/iot-covid-detector-ror/issues/34)

---
#### Description:
Adds a Heroku worker to run mqtt task

---
#### Notes:
* N/A

---
#### Risk:
* Not sure what happens if the rake task fails. Heroku automatically run the command again?
